### PR TITLE
add the addtional columns from the region table #3

### DIFF
--- a/tdp_covid19/korea_columns.py
+++ b/tdp_covid19/korea_columns.py
@@ -22,5 +22,17 @@ columns = [
     ['confirmed_date', 'categorical'],
     ['released_date', 'categorical'],
     ['deceased_date', 'categorical'],
-    ['state', 'categorical']
+    ['state', 'categorical'],
+    ['province_code', 'number'],
+    ['latitude', 'number'],
+    ['longitude', 'number'],
+    ['elementary_school_count', 'number'],
+    ['kindergarten_count', 'number'],
+    ['university_count', 'number'],
+    ['academy_ratio', 'number'],
+    ['elderly_population_ratio', 'number'],
+    ['elderly_alone_ratio', 'number'],
+    ['nursing_home_count', 'number'],
+    ['province_population', 'number'],
+    ['province_area_km2', 'number']
 ]


### PR DESCRIPTION
closes #3 

## Summary

### Implementation
`korea_columns.py`: added the columns from the region table

### DB
for detailed description Wiki (https://wiki.datavisyn.io/internal-jku/cohort/covid-data)
- Added new materialized view: **korea**
- chaged the table of **korea** to **korea_patient**
- joined tables with attribuite **province**