### PR TITLE
Add `infected` Column to the Patient Table in the DB

### DIFF
--- a/tdp_covid19/korea_columns.py
+++ b/tdp_covid19/korea_columns.py
@@ -17,6 +17,7 @@ columns = [
     ['infection_case', 'categorical'],
     ['infection_order', 'number'],
     ['infected_by', 'number'],
+    ['infected', 'number'],
     ['contact_number', 'number'],
     ['symptom_onset_date', 'categorical'],
     ['confirmed_date', 'categorical'],


### PR DESCRIPTION
closes #5 

## Summary

### Implmentation App
`korea_columns.py`: added column description

### Implementation DB
For detailed description see Wiki: https://wiki.datavisyn.io/internal-jku/cohort/covid-data
- added new column `infected`
- set values for new column
- removed old materialized view
- updated materialized view statement
- created new materialized view
- gave `covid_r` rights

**Screenshot**
Age distribution for All / infected >= 3 / infected >= 10
![image](https://user-images.githubusercontent.com/42137747/79609566-43bda180-80f7-11ea-9d7e-b054cd423caa.png)

